### PR TITLE
Fix: Update type hints for Python 3.9 compatibility

### DIFF
--- a/webnovel_archiver/cli/main.py
+++ b/webnovel_archiver/cli/main.py
@@ -1,4 +1,5 @@
 import click
+from typing import Optional
 from webnovel_archiver.cli.handlers import archive_story_handler
 
 @click.group()
@@ -15,7 +16,7 @@ def archiver():
 @click.option('--sentence-removal-file', default=None, type=click.Path(exists=True), help='Path to a JSON file for sentence removal rules.')
 @click.option('--no-sentence-removal', is_flag=True, default=False, help='Disable sentence removal even if a file is provided.')
 @click.option('--chapters-per-volume', default=None, type=int, help='Number of chapters per EPUB volume. Default is all in one volume.')
-def archive_story(story_url: str, output_dir: str | None, ebook_title_override: str | None, keep_temp_files: bool, force_reprocessing: bool, sentence_removal_file: str | None, no_sentence_removal: bool, chapters_per_volume: int | None):
+def archive_story(story_url: str, output_dir: Optional[str], ebook_title_override: Optional[str], keep_temp_files: bool, force_reprocessing: bool, sentence_removal_file: Optional[str], no_sentence_removal: bool, chapters_per_volume: Optional[int]):
     """Archives a webnovel from a given URL with specified options."""
     archive_story_handler(
         story_url=story_url,

--- a/webnovel_archiver/core/builders/epub_generator.py
+++ b/webnovel_archiver/core/builders/epub_generator.py
@@ -1,4 +1,4 @@
-import ebooklib
+import ebooklib # type: ignore
 from ebooklib import epub
 import os
 import datetime

--- a/webnovel_archiver/core/orchestrator.py
+++ b/webnovel_archiver/core/orchestrator.py
@@ -132,6 +132,10 @@ def archive_story(
     for chapter_info in chapters_info_list:
         logger.info(f"Processing chapter: {chapter_info.chapter_title} (URL: {chapter_info.chapter_url})")
 
+        if chapter_info.chapter_url is None:
+            logger.warning(f"Chapter {chapter_info.chapter_title} (Order: {chapter_info.download_order}) has no URL. Skipping.")
+            continue
+
         if not force_reprocessing and chapter_info.chapter_url in existing_chapters_map:
             existing_chapter_details = existing_chapters_map[chapter_info.chapter_url]
             # Check if local_raw_filename and local_processed_filename exist and are not None or empty


### PR DESCRIPTION
The existing codebase used the `|` operator for union type hints (e.g., `str | None`), which was introduced in Python 3.10. This caused `TypeError` exceptions when running on Python 3.9.

This commit updates all incompatible type hints to use `typing.Union` or `typing.Optional` for Python 3.7-3.9 compatibility.

Specifically:
- Changed `X | None` to `Optional[X]` in `webnovel_archiver/cli/main.py`.
- Add missing `webnovel_archiver/__init__.py` to help MyPy identify the package.
- Installed type stubs for `beautifulsoup4` and `requests`.
- Added `# type: ignore` to `ebooklib` import as no stubs were available.
- Fixed various type errors in `webnovel_archiver/core/fetchers/royalroad_fetcher.py` and `webnovel_archiver/core/orchestrator.py` reported by MyPy.

MyPy static analysis now passes with `--python-version 3.9`.