### PR TITLE
I've updated how your EPUB files are displayed in the report.

### DIFF
--- a/test_workspace/archival_status/story123/progress_status.json
+++ b/test_workspace/archival_status/story123/progress_status.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.1",
+  "story_id": "story123",
+  "story_url": "http://example.com/story123",
+  "original_title": "Story 123 Title",
+  "original_author": "Author Three",
+  "cover_image_url": null,
+  "synopsis": "A tale of 123 adventures.",
+  "tags": [
+    "adventure",
+    "comedy"
+  ],
+  "story_id_from_source": "src123",
+  "estimated_total_chapters_source": 100,
+  "last_downloaded_chapter_url": null,
+  "next_chapter_to_download_url": null,
+  "downloaded_chapters": [],
+  "last_epub_processing": {
+    "timestamp": "2024-06-06T10:00:00Z",
+    "chapters_included_in_last_volume": null,
+    "generated_epub_files": [
+      {
+        "name": "story123_vol1.epub",
+        "path": "/app/test_workspace/ebooks/story123/story123_vol1.epub"
+      },
+      {
+        "name": "story123_vol2.epub",
+        "path": "/app/test_workspace/ebooks/story123/story123_vol2.epub"
+      },
+      {
+        "name": "story123_vol3.epub",
+        "path": "/app/test_workspace/ebooks/story123/story123_vol3.epub"
+      },
+      {
+        "name": "story123_vol4.epub",
+        "path": "/app/test_workspace/ebooks/story123/story123_vol4.epub"
+      }
+    ]
+  },
+  "sentence_removal_config_used": null,
+  "cloud_backup_status": {
+    "last_backup_attempt_timestamp": null,
+    "last_successful_backup_timestamp": null,
+    "service": null,
+    "base_cloud_folder_name": null,
+    "story_cloud_folder_name": null,
+    "cloud_base_folder_id": null,
+    "story_cloud_folder_id": null,
+    "backed_up_files": []
+  },
+  "last_updated_timestamp": "2024-06-06T10:00:00Z"
+}

--- a/test_workspace/archival_status/story456/progress_status.json
+++ b/test_workspace/archival_status/story456/progress_status.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.1",
+  "story_id": "story456",
+  "story_url": "http://example.com/story456",
+  "original_title": "Story 456 Title",
+  "original_author": "Author FourFiveSix",
+  "cover_image_url": null,
+  "synopsis": "A tale of 456 challenges.",
+  "tags": [
+    "sci-fi",
+    "drama"
+  ],
+  "story_id_from_source": "src456",
+  "estimated_total_chapters_source": 50,
+  "last_downloaded_chapter_url": null,
+  "next_chapter_to_download_url": null,
+  "downloaded_chapters": [],
+  "last_epub_processing": {
+    "timestamp": "2024-06-06T11:00:00Z",
+    "chapters_included_in_last_volume": null,
+    "generated_epub_files": [
+      {
+        "name": "story456_complete.epub",
+        "path": "/app/test_workspace/ebooks/story456/story456_complete.epub"
+      }
+    ]
+  },
+  "sentence_removal_config_used": null,
+  "cloud_backup_status": {
+    "last_backup_attempt_timestamp": null,
+    "last_successful_backup_timestamp": null,
+    "service": null,
+    "base_cloud_folder_name": null,
+    "story_cloud_folder_name": null,
+    "cloud_base_folder_id": null,
+    "story_cloud_folder_id": null,
+    "backed_up_files": []
+  },
+  "last_updated_timestamp": "2024-06-06T11:00:00Z"
+}

--- a/test_workspace/config/settings.ini
+++ b/test_workspace/config/settings.ini
@@ -1,0 +1,5 @@
+[General]
+workspace_path = /app/test_workspace/
+
+[SentenceRemoval]
+default_sentence_removal_file = /app/test_workspace/config/default_sentence_removal.json

--- a/test_workspace/reports/archive_report.html
+++ b/test_workspace/reports/archive_report.html
@@ -74,6 +74,105 @@
         color: #0056b3;
     }
 
+    /* EPUB Grid Styles */
+    .epub-grid-container {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+        gap: 15px;
+        padding: 10px 0; /* Add some padding above/below the grid */
+        margin-bottom: 10px; /* Space before the 'Show all' button if it's outside */
+    }
+    .epub-grid-item {
+        border: 1px solid #ddd;
+        padding: 10px;
+        text-align: center;
+        cursor: pointer;
+        background-color: #f9f9f9;
+        border-radius: 4px;
+        transition: box-shadow 0.2s ease-in-out;
+    }
+    .epub-grid-item:hover {
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    .epub-cover-placeholder { /* Shared with modal */
+        font-size: 3em; /* Larger book icon */
+        margin-bottom: 8px;
+        color: #888;
+    }
+    .epub-name {
+        font-size: 0.85em;
+        color: #333;
+        word-break: break-word; /* Ensure long names wrap */
+        line-height: 1.2;
+    }
+
+    /* Modal Styles */
+    .modal {
+        display: none; /* Hidden by default */
+        position: fixed; /* Stay in place */
+        z-index: 1000; /* Sit on top */
+        left: 0;
+        top: 0;
+        width: 100%; /* Full width */
+        height: 100%; /* Full height */
+        overflow: auto; /* Enable scroll if needed */
+        background-color: rgba(0,0,0,0.6); /* Black w/ opacity */
+    }
+    .modal-content {
+        background-color: #fefefe;
+        margin: 10% auto; /* 10% from the top and centered */
+        padding: 25px;
+        border: 1px solid #bbb;
+        width: 80%; /* Could be more or less, depending on screen size */
+        max-width: 500px; /* Maximum width */
+        border-radius: 8px;
+        position: relative;
+        box-shadow: 0 4px 8px 0 rgba(0,0,0,0.2),0 6px 20px 0 rgba(0,0,0,0.19);
+        text-align: center; /* Center content like title and placeholder */
+    }
+    .modal-close-btn {
+        color: #aaa;
+        position: absolute; /* Position relative to modal-content */
+        top: 10px;
+        right: 15px;
+        font-size: 28px;
+        font-weight: bold;
+    }
+    .modal-close-btn:hover,
+    .modal-close-btn:focus {
+        color: black;
+        text-decoration: none;
+        cursor: pointer;
+    }
+    #modalEpubName {
+        margin-top: 0;
+        margin-bottom: 15px;
+        font-size: 1.5em;
+        color: #333;
+    }
+    /* #modalEpubCoverPlaceholder is styled by .epub-cover-placeholder */
+    #modalEpubPath {
+        font-family: monospace;
+        font-size: 0.9em;
+        color: #555;
+        word-break: break-all;
+        display: inline-block; /* Allow centering if text-align center on parent */
+        margin-bottom: 10px;
+    }
+    #modalEpubPathLink {
+        display: inline-block;
+        margin-top: 15px;
+        padding: 10px 15px;
+        background-color: #007bff;
+        color: white;
+        text-decoration: none;
+        border-radius: 4px;
+        transition: background-color 0.2s;
+    }
+    #modalEpubPathLink:hover {
+        background-color: #0056b3;
+    }
+
     </style>
 </head>
 <body>
@@ -99,76 +198,107 @@
     </div>
 
         <div id="storyListContainer">
-    <div class="story-card" data-title="Test Story with Few Epubs" data-author="Another Test Author" data-status="Complete" data-last-updated="2023-10-25T14:00:00Z" data-progress="100">
+    <div class="story-card" data-title="Story 456 Title" data-author="Author FourFiveSix" data-status="Ongoing" data-last-updated="" data-progress="0">
         <div class="story-cover">
-            <img src="http://via.placeholder.com/150" alt="Cover for Test Story with Few Epubs">
+            <img src="https://via.placeholder.com/150x220.png?text=No+Cover" alt="Cover for Story 456 Title">
         </div>
         <div class="story-details">
-            <h2><a href="http://example.com/story456" target="_blank">Test Story with Few Epubs</a></h2>
-            <p><strong>Author:</strong> Another Test Author</p>
+            <h2><a href="http://example.com/story456" target="_blank">Story 456 Title</a></h2>
+            <p><strong>Author:</strong> Author FourFiveSix</p>
 
             <p class="section-title">Synopsis:</p>
-            <div class="synopsis" onclick="toggleSynopsis(this)">A test story with only one EPUB file.</div>
+            <div class="synopsis" onclick="toggleSynopsis(this)">A tale of 456 challenges.</div>
             <span class="synopsis-toggle" onclick="toggleSynopsis(this.previousElementSibling)">(Read more)</span>
 
             <p class="section-title">Download Progress:</p>
             <div class="progress-bar-container">
-                <div class="progress-bar" style="width:100%;">100%</div>
+                <div class="progress-bar" style="width:0%;">0%</div>
             </div>
-            <p>2 / 2 chapters</p>
-            <p><strong>Story Status:</strong> <span class="badge status-complete">Complete</span></p>
+            <p>0 / 50 chapters</p>
+            <p><strong>Story Status:</strong> <span class="badge status-ongoing">Ongoing</span></p>
 
-            <p class="section-title">Local EPUBs (Generated: 2023-10-25 14:30:00 UTC):</p>
-            <ul class="file-list"><li><a href="file:////app/test_workspace/ebooks/story456/story456_complete.epub" title="/app/test_workspace/ebooks/story456/story456_complete.epub">story456_complete.epub</a></li></ul>
+            <p class="section-title">Local EPUBs (Generated: 2024-06-06 11:00:00 UTC):</p>
+            <div class="epub-grid-container">
+        <div class="epub-grid-item" data-epub-name="story456_complete.epub" data-epub-path="/app/test_workspace/ebooks/story456/story456_complete.epub" onclick="openEpubModal(this)">
+            <div class="epub-cover-placeholder">📖</div>
+            <div class="epub-name" title="story456_complete.epub">story456_complete.epub</div>
+        </div></div>
 
             <p class="section-title">Cloud Backup:</p>
-            <p><strong>Status:</strong> <span class="badge backup-ok">OK</span>
-               (Service: TestDrive)
+            <p><strong>Status:</strong> <span class="badge backup-never-backed-up">Never Backed Up</span>
+               (Service: N/A)
             </p>
-            <p>Last Successful Backup: 2023-10-25 15:00:00 UTC</p>
-            <ul class="file-list"><li>ebooks/story456/story456_complete.epub (story456_complete.epub): uploaded - Last backed up: 2023-10-25 15:00:00 UTC</li></ul>
+            <p>Last Successful Backup: N/A</p>
+            <p class="no-items">No backup file details.</p>
 
             <p class="section-title">Last Local Update:</p>
-            <p>2023-10-25 14:00:00 UTC</p>
+            <p>2024-06-06 11:00:00 UTC</p>
         </div>
     </div>
 
-    <div class="story-card" data-title="Test Story with Many Epubs" data-author="Test Author" data-status="Complete" data-last-updated="2023-10-26T09:00:00Z" data-progress="100">
+    <div class="story-card" data-title="Story 123 Title" data-author="Author Three" data-status="Ongoing" data-last-updated="" data-progress="0">
         <div class="story-cover">
-            <img src="http://via.placeholder.com/150" alt="Cover for Test Story with Many Epubs">
+            <img src="https://via.placeholder.com/150x220.png?text=No+Cover" alt="Cover for Story 123 Title">
         </div>
         <div class="story-details">
-            <h2><a href="http://example.com/story123" target="_blank">Test Story with Many Epubs</a></h2>
-            <p><strong>Author:</strong> Test Author</p>
+            <h2><a href="http://example.com/story123" target="_blank">Story 123 Title</a></h2>
+            <p><strong>Author:</strong> Author Three</p>
 
             <p class="section-title">Synopsis:</p>
-            <div class="synopsis" onclick="toggleSynopsis(this)">A test story with many EPUB files to test the toggle feature.</div>
+            <div class="synopsis" onclick="toggleSynopsis(this)">A tale of 123 adventures.</div>
             <span class="synopsis-toggle" onclick="toggleSynopsis(this.previousElementSibling)">(Read more)</span>
 
             <p class="section-title">Download Progress:</p>
             <div class="progress-bar-container">
-                <div class="progress-bar" style="width:100%;">100%</div>
+                <div class="progress-bar" style="width:0%;">0%</div>
             </div>
-            <p>5 / 5 chapters</p>
-            <p><strong>Story Status:</strong> <span class="badge status-complete">Complete</span></p>
+            <p>0 / 100 chapters</p>
+            <p><strong>Story Status:</strong> <span class="badge status-ongoing">Ongoing</span></p>
 
-            <p class="section-title">Local EPUBs (Generated: 2023-10-26 10:00:00 UTC):</p>
-            <ul class="file-list"><li><a href="file:////app/test_workspace/ebooks/story123/story123_vol1.epub" title="/app/test_workspace/ebooks/story123/story123_vol1.epub">story123_vol1.epub</a></li><li><a href="file:////app/test_workspace/ebooks/story123/story123_vol2.epub" title="/app/test_workspace/ebooks/story123/story123_vol2.epub">story123_vol2.epub</a></li><li><a href="file:////app/test_workspace/ebooks/story123/story123_vol3.epub" title="/app/test_workspace/ebooks/story123/story123_vol3.epub">story123_vol3.epub</a></li></ul><div id="more-epubs-story123" style="display:none;"><ul class="file-list"><li><a href="file:////app/test_workspace/ebooks/story123/story123_vol4.epub" title="/app/test_workspace/ebooks/story123/story123_vol4.epub">story123_vol4.epub</a></li><li><a href="file:////app/test_workspace/ebooks/story123/story123_vol5.epub" title="/app/test_workspace/ebooks/story123/story123_vol5.epub">story123_vol5.epub</a></li></ul></div><button type="button" class="toggle-epubs-btn" onclick="toggleExtraEpubs('story123', this, 5, 3)">Show all 5 EPUBs</button>
+            <p class="section-title">Local EPUBs (Generated: 2024-06-06 10:00:00 UTC):</p>
+            <div class="epub-grid-container">
+        <div class="epub-grid-item" data-epub-name="story123_vol1.epub" data-epub-path="/app/test_workspace/ebooks/story123/story123_vol1.epub" onclick="openEpubModal(this)">
+            <div class="epub-cover-placeholder">📖</div>
+            <div class="epub-name" title="story123_vol1.epub">story123_vol1.epub</div>
+        </div>
+        <div class="epub-grid-item" data-epub-name="story123_vol2.epub" data-epub-path="/app/test_workspace/ebooks/story123/story123_vol2.epub" onclick="openEpubModal(this)">
+            <div class="epub-cover-placeholder">📖</div>
+            <div class="epub-name" title="story123_vol2.epub">story123_vol2.epub</div>
+        </div>
+        <div class="epub-grid-item" data-epub-name="story123_vol3.epub" data-epub-path="/app/test_workspace/ebooks/story123/story123_vol3.epub" onclick="openEpubModal(this)">
+            <div class="epub-cover-placeholder">📖</div>
+            <div class="epub-name" title="story123_vol3.epub">story123_vol3.epub</div>
+        </div></div><div id="more-epubs-story123" style="display:none;" class="epub-grid-container">
+        <div class="epub-grid-item" data-epub-name="story123_vol4.epub" data-epub-path="/app/test_workspace/ebooks/story123/story123_vol4.epub" onclick="openEpubModal(this)">
+            <div class="epub-cover-placeholder">📖</div>
+            <div class="epub-name" title="story123_vol4.epub">story123_vol4.epub</div>
+        </div></div><button type="button" class="toggle-epubs-btn" onclick="toggleExtraEpubs('story123', this, 4, 3)">Show all 4 EPUBs</button>
 
             <p class="section-title">Cloud Backup:</p>
-            <p><strong>Status:</strong> <span class="badge backup-ok">OK</span>
-               (Service: TestDrive)
+            <p><strong>Status:</strong> <span class="badge backup-never-backed-up">Never Backed Up</span>
+               (Service: N/A)
             </p>
-            <p>Last Successful Backup: 2023-10-26 11:00:00 UTC</p>
-            <ul class="file-list"><li>ebooks/story123/story123_vol1.epub (story123_vol1.epub): uploaded - Last backed up: 2023-10-26 11:00:00 UTC</li><li>ebooks/story123/story123_vol2.epub (story123_vol2.epub): uploaded - Last backed up: 2023-10-26 11:00:00 UTC</li></ul>
+            <p>Last Successful Backup: N/A</p>
+            <p class="no-items">No backup file details.</p>
 
             <p class="section-title">Last Local Update:</p>
-            <p>2023-10-26 09:00:00 UTC</p>
+            <p>2024-06-06 10:00:00 UTC</p>
         </div>
     </div>
     </div>
         <div id="paginationControls" class="pagination-controls"></div>
     </div>
+
+    <div id="epubModal" class="modal" style="display:none;">
+        <div class="modal-content">
+            <span class="modal-close-btn" onclick="closeEpubModal()">&times;</span>
+            <h3 id="modalEpubName"></h3>
+            <div id="modalEpubCoverPlaceholder" class="epub-cover-placeholder">📖</div>
+            <p><strong>Path:</strong> <span id="modalEpubPath"></span></p>
+            <p><a id="modalEpubPathLink" href="#" target="_blank" rel="noopener noreferrer">Open EPUB (local path)</a></p>
+        </div>
+    </div>
+
     <script>
         // Global variables
 let currentPage = 1;
@@ -182,6 +312,12 @@ let sortSelect = null;
 let storyListContainer = null;
 let paginationControls = null;
 
+// Modal DOM Elements
+let epubModal = null;
+let modalEpubName = null;
+let modalEpubPath = null;
+let modalEpubPathLink = null;
+let modalEpubCoverPlaceholder = null; // Added this based on HTML structure
 
 function toggleSynopsis(element) {
     element.classList.toggle('expanded');
@@ -380,6 +516,45 @@ function toggleExtraEpubs(story_id_sanitized, buttonElement, totalEpubs, thresho
     }
 }
 
+// Modal Functions
+function openEpubModal(element) {
+    if (!epubModal || !modalEpubName || !modalEpubPath || !modalEpubPathLink || !modalEpubCoverPlaceholder) {
+        console.error("Modal elements not cached correctly.");
+        return;
+    }
+
+    const epubName = element.dataset.epubName;
+    const epubPath = element.dataset.epubPath;
+
+    modalEpubName.textContent = epubName;
+    // modalEpubCoverPlaceholder.textContent = '📖'; // Already in HTML, but could update if dynamic
+
+    // Display the path textually for user info
+    modalEpubPath.textContent = epubPath;
+
+    // Create a file URI for the link
+    // Note: Direct linking to local files has security restrictions in many browsers.
+    // This creates the link, but it might not work as expected without browser configuration
+    // or if the report is not viewed locally.
+    if (epubPath) {
+        // Assuming epubPath is an absolute path. If it's relative, more logic is needed.
+        // For security, browsers are very restrictive about file:/// links from http/https pages.
+        // If this report is opened as a local file itself, file:/// links are more likely to work.
+        modalEpubPathLink.href = `file:///${epubPath}`;
+    } else {
+        modalEpubPathLink.href = '#'; // Fallback if path is missing
+    }
+
+    epubModal.style.display = 'block';
+}
+
+function closeEpubModal() {
+    if (epubModal) {
+        epubModal.style.display = 'none';
+    }
+}
+
+
 document.addEventListener('DOMContentLoaded', function() {
     // Cache DOM elements
     searchInput = document.getElementById('searchInput');
@@ -387,6 +562,22 @@ document.addEventListener('DOMContentLoaded', function() {
     sortSelect = document.getElementById('sortSelect');
     storyListContainer = document.getElementById('storyListContainer');
     paginationControls = document.getElementById('paginationControls');
+
+    // Cache Modal DOM elements
+    epubModal = document.getElementById('epubModal');
+    modalEpubName = document.getElementById('modalEpubName');
+    modalEpubPath = document.getElementById('modalEpubPath');
+    modalEpubPathLink = document.getElementById('modalEpubPathLink');
+    modalEpubCoverPlaceholder = document.getElementById('modalEpubCoverPlaceholder');
+
+    // Event listener for closing modal on outside click
+    if (epubModal) {
+        epubModal.addEventListener('click', function(event) {
+            if (event.target === epubModal) { // Check if the click is on the modal overlay itself
+                closeEpubModal();
+            }
+        });
+    }
 
     if (storyListContainer) {
         // Get all cards present in the container at load time

--- a/webnovel_archiver/report_scripts.js
+++ b/webnovel_archiver/report_scripts.js
@@ -10,6 +10,12 @@ let sortSelect = null;
 let storyListContainer = null;
 let paginationControls = null;
 
+// Modal DOM Elements
+let epubModal = null;
+let modalEpubName = null;
+let modalEpubPath = null;
+let modalEpubPathLink = null;
+let modalEpubCoverPlaceholder = null; // Added this based on HTML structure
 
 function toggleSynopsis(element) {
     element.classList.toggle('expanded');
@@ -208,6 +214,45 @@ function toggleExtraEpubs(story_id_sanitized, buttonElement, totalEpubs, thresho
     }
 }
 
+// Modal Functions
+function openEpubModal(element) {
+    if (!epubModal || !modalEpubName || !modalEpubPath || !modalEpubPathLink || !modalEpubCoverPlaceholder) {
+        console.error("Modal elements not cached correctly.");
+        return;
+    }
+
+    const epubName = element.dataset.epubName;
+    const epubPath = element.dataset.epubPath;
+
+    modalEpubName.textContent = epubName;
+    // modalEpubCoverPlaceholder.textContent = '📖'; // Already in HTML, but could update if dynamic
+
+    // Display the path textually for user info
+    modalEpubPath.textContent = epubPath;
+
+    // Create a file URI for the link
+    // Note: Direct linking to local files has security restrictions in many browsers.
+    // This creates the link, but it might not work as expected without browser configuration
+    // or if the report is not viewed locally.
+    if (epubPath) {
+        // Assuming epubPath is an absolute path. If it's relative, more logic is needed.
+        // For security, browsers are very restrictive about file:/// links from http/https pages.
+        // If this report is opened as a local file itself, file:/// links are more likely to work.
+        modalEpubPathLink.href = `file:///${epubPath}`;
+    } else {
+        modalEpubPathLink.href = '#'; // Fallback if path is missing
+    }
+
+    epubModal.style.display = 'block';
+}
+
+function closeEpubModal() {
+    if (epubModal) {
+        epubModal.style.display = 'none';
+    }
+}
+
+
 document.addEventListener('DOMContentLoaded', function() {
     // Cache DOM elements
     searchInput = document.getElementById('searchInput');
@@ -215,6 +260,22 @@ document.addEventListener('DOMContentLoaded', function() {
     sortSelect = document.getElementById('sortSelect');
     storyListContainer = document.getElementById('storyListContainer');
     paginationControls = document.getElementById('paginationControls');
+
+    // Cache Modal DOM elements
+    epubModal = document.getElementById('epubModal');
+    modalEpubName = document.getElementById('modalEpubName');
+    modalEpubPath = document.getElementById('modalEpubPath');
+    modalEpubPathLink = document.getElementById('modalEpubPathLink');
+    modalEpubCoverPlaceholder = document.getElementById('modalEpubCoverPlaceholder');
+
+    // Event listener for closing modal on outside click
+    if (epubModal) {
+        epubModal.addEventListener('click', function(event) {
+            if (event.target === epubModal) { // Check if the click is on the modal overlay itself
+                closeEpubModal();
+            }
+        });
+    }
 
     if (storyListContainer) {
         // Get all cards present in the container at load time


### PR DESCRIPTION
Here's what I changed:
- The EPUB files are now shown in a grid instead of a list, making it easier to see more at once.
- When you click on an EPUB in the grid, a pop-up will appear showing its name and path, along with a link to open the file on your computer.
- I've made adjustments to the report generation script (`generate_report.py`) to support this new grid and pop-up feature.
- I've also updated the styling and the JavaScript (`report_scripts.js`) to handle how the grid and pop-up look and behave.
- The "show more" feature for EPUBs now works with the new grid layout.