### PR TITLE
Refactor: Remove status filter and fix report search/sort

### DIFF
--- a/webnovel_archiver/generate_report.py
+++ b/webnovel_archiver/generate_report.py
@@ -600,50 +600,8 @@ def main():
             <option value="last_updated_asc">Sort by Last Updated (Oldest First)</option>
             <option value="progress_desc">Sort by Progress (Highest First)</option>
         </select>
-        <select id="filterStatusSelect" onchange="filterStories()" aria-label="Filter stories by status">
-            <option value="">Filter by Status (All)</option>
-            <option value="Complete">Complete</option>
-            <option value="Ongoing">Ongoing</option>
-            <option value="Possibly Complete (Total Unknown)">Possibly Complete</option>
-            <option value="Unknown (No chapters downloaded, total unknown)">Unknown</option>
-            {status_options_html}
-        </select>
     </div>
     """
-
-    # Dynamically generate status options for filter based on available statuses
-    # This can be improved by getting unique statuses from processed_stories
-    # For now, using the provided list plus a placeholder for more.
-    # A more robust way would be:
-    # available_statuses = sorted(list(set(s['status'] for s in processed_stories if s.get('status'))))
-    # status_options_html_list = [f'<option value="{html.escape(s)}">{html.escape(s)}</option>' for s in available_statuses]
-    # For simplicity, using the fixed list from prompt for now.
-
-    unique_statuses = set()
-    if processed_stories:
-        for s_data in processed_stories:
-            if s_data.get('status'):
-                unique_statuses.add(s_data['status'])
-
-    # status_options_html_list = [f'<option value="{html.escape(status)}">{html.escape(status)}</option>' for status in sorted(list(unique_statuses))]
-
-
-    # Replacing placeholder in header_controls
-    # This is a bit simplistic; a more robust template engine would be better for complex HTML.
-    # For now, just ensuring the placeholder is removed or filled.
-    # The prompt had a fixed list, let's stick to that for simplicity and add others if found
-    fixed_status_options = [
-        "Complete", "Ongoing", "Possibly Complete (Total Unknown)",
-        "Unknown (No chapters downloaded, total unknown)" # This one is long, matches the class
-    ]
-
-    # Combine fixed options with any other unique statuses found, ensuring no duplicates and proper escaping
-    all_available_statuses = sorted(list(set(fixed_status_options + list(unique_statuses))))
-
-    status_options_for_filter_html = "".join([f'<option value="{html.escape(s)}">{html.escape(s)}</option>' for s in all_available_statuses])
-
-    header_controls = header_controls.replace("{status_options_html}", status_options_for_filter_html)
-
 
     main_body_content = f'''<div class="container">
         <h1 class="report-title">Webnovel Archive Report</h1>

--- a/webnovel_archiver/report_scripts.js
+++ b/webnovel_archiver/report_scripts.js
@@ -5,7 +5,6 @@ let allVisibleStoryCards = []; // To store all cards initially or after filterin
 
 // DOM Element caching (populated in DOMContentLoaded)
 let searchInput = null;
-let filterStatusSelect = null;
 let sortSelect = null;
 let storyListContainer = null;
 let paginationControls = null;
@@ -121,10 +120,9 @@ function handlePageChange(newPage, totalItems, displayFn) {
 }
 
 function filterStories() {
-    if (!searchInput || !filterStatusSelect || !storyListContainer) return; // Ensure elements are cached
+    if (!searchInput || !storyListContainer) return; // Ensure elements are cached
 
     let filterTitle = searchInput.value.toUpperCase();
-    let statusFilter = filterStatusSelect.value;
 
     // Reset to all cards from the DOM before filtering
     // This assumes all cards are initially within storyListContainer
@@ -133,11 +131,9 @@ function filterStories() {
     allVisibleStoryCards = originalCards.filter(card => {
         let title = (card.dataset.title || '').toUpperCase();
         let author = (card.dataset.author || '').toUpperCase();
-        let status = card.dataset.status || '';
 
         let titleMatch = title.includes(filterTitle) || author.includes(filterTitle);
-        let statusMatch = (statusFilter === "" || status === statusFilter);
-        return titleMatch && statusMatch;
+        return titleMatch;
     });
 
     // No direct DOM manipulation for filtering here; pagination handles display
@@ -156,7 +152,7 @@ function sortStories() {
     if (!allVisibleStoryCards || allVisibleStoryCards.length === 0) {
         const currentCardsInDOM = Array.from(storyListContainer.children).filter(child => child.classList.contains('story-card'));
          // Check if cards are currently displayed by a filter or if it's an empty filter result
-        const activeFilter = searchInput.value || filterStatusSelect.value;
+        const activeFilter = searchInput.value;
         if (!activeFilter && currentCardsInDOM.length > 0) {
             // If no filter is active, and cards are in DOM, use them (e.g. initial load, no filter applied yet)
             allVisibleStoryCards = currentCardsInDOM;
@@ -215,7 +211,6 @@ function toggleExtraEpubs(story_id_sanitized, buttonElement, totalEpubs, thresho
 document.addEventListener('DOMContentLoaded', function() {
     // Cache DOM elements
     searchInput = document.getElementById('searchInput');
-    filterStatusSelect = document.getElementById('filterStatusSelect');
     sortSelect = document.getElementById('sortSelect');
     storyListContainer = document.getElementById('storyListContainer');
     paginationControls = document.getElementById('paginationControls');
@@ -241,9 +236,6 @@ document.addEventListener('DOMContentLoaded', function() {
     // Add event listeners for filter and sort controls
     if (searchInput) {
         searchInput.addEventListener('keyup', filterStories);
-    }
-    if (filterStatusSelect) {
-        filterStatusSelect.addEventListener('change', filterStories);
     }
     if (sortSelect) {
         sortSelect.addEventListener('change', sortStories);


### PR DESCRIPTION
This commit addresses issues with the HTML report generation:

- Removed the "Filter by Status" dropdown from the report's header controls in `generate_report.py`.
- Removed the corresponding Python logic that generated the status filter options.
- Updated `report_scripts.js` to remove all JavaScript code related to the status filter.
    - The `filterStories` function now filters only based on the text search input (title/author).
    - References to the status filter DOM element and its event listeners have been removed.

The search and sort functionalities are now expected to work correctly with the text-based search filter.