### PR TITLE
feat: Upload HTML report during cloud backup

### DIFF
--- a/tests/cli/test_handlers.py
+++ b/tests/cli/test_handlers.py
@@ -11,8 +11,19 @@ MOCK_ORCHESTRATOR_PATH = "webnovel_archiver.cli.handlers.call_orchestrator_archi
 
 # Mock ConfigManager if it's used for default path
 MOCK_CONFIG_MANAGER_PATH = "webnovel_archiver.cli.handlers.ConfigManager"
-MOCK_OS_PATH_EXISTS = "webnovel_archiver.cli.handlers.os.path.exists"
-MOCK_LOGGER_PATH = "webnovel_archiver.cli.handlers.logger"
+MOCK_OS_PATH_EXISTS = "webnovel_archiver.cli.handlers.os.path.exists" # Used for files
+MOCK_OS_PATH_ISDIR = "webnovel_archiver.cli.handlers.os.path.isdir" # Used for directories
+MOCK_OS_LISTDIR = "webnovel_archiver.cli.handlers.os.listdir"
+MOCK_LOGGER_PATH = "webnovel_archiver.cli.handlers.logger" # Already present
+MOCK_CLICK_ECHO_PATH = "webnovel_archiver.cli.handlers.click.echo" # For capturing user messages
+
+# Mocks for cloud_backup_handler specific dependencies
+MOCK_GDRIVE_SYNC_PATH = "webnovel_archiver.cli.handlers.GDriveSync"
+MOCK_PM_PATH = "webnovel_archiver.cli.handlers.pm" # For progress_manager module
+
+
+# Import the handler to be tested
+from webnovel_archiver.cli.handlers import cloud_backup_handler
 
 
 @pytest.fixture
@@ -273,3 +284,210 @@ def test_archive_story_warns_if_cli_sr_file_not_found(mock_config_manager_instan
         )
         assert f"Sentence removal file provided via CLI not found: {non_existent_cli_sr_path}" in caplog.text
         mock_config_manager_instance.get_default_sentence_removal_file.assert_not_called()
+
+
+# Tests for cloud_backup_handler HTML report upload
+
+@pytest.fixture
+def mock_cloud_backup_common_deps(monkeypatch):
+    """Fixture to mock common dependencies for cloud_backup_handler tests."""
+    mock_cm_instance = mock.Mock(spec=ConfigManager)
+    mock_cm_instance.get_workspace_path.return_value = "/mocked/workspace"
+    monkeypatch.setattr(MOCK_CONFIG_MANAGER_PATH, mock.Mock(return_value=mock_cm_instance))
+
+    mock_gdrive_sync_instance = mock.Mock(spec_set=["create_folder_if_not_exists", "upload_file", "get_file_metadata", "is_remote_older"])
+    mock_gdrive_sync_instance.create_folder_if_not_exists.return_value = "dummy_root_folder_id"
+    # upload_file mock will be configured per test as needed
+    monkeypatch.setattr(MOCK_GDRIVE_SYNC_PATH, mock.Mock(return_value=mock_gdrive_sync_instance))
+
+    # Mock progress_manager functions
+    monkeypatch.setattr(f"{MOCK_PM_PATH}.get_progress_filepath", mock.Mock(return_value="/mocked/workspace/archival_status/story1/progress_status.json"))
+    monkeypatch.setattr(f"{MOCK_PM_PATH}.load_progress", mock.Mock(return_value={"story_id": "story1", "title": "Test Story"}))
+    monkeypatch.setattr(f"{MOCK_PM_PATH}.get_epub_file_details", mock.Mock(return_value=[])) # No epubs by default
+    monkeypatch.setattr(f"{MOCK_PM_PATH}.update_cloud_backup_status", mock.Mock())
+    monkeypatch.setattr(f"{MOCK_PM_PATH}.save_progress", mock.Mock())
+
+
+    # Mock os.path.isdir to simulate that archival_status and ebooks_base_dir exist
+    # and that story_id directories exist if os.listdir returns them.
+    def mock_isdir_logic(path):
+        if path in ["/mocked/workspace/archival_status", "/mocked/workspace/ebooks", "/mocked/workspace/archival_status/story1"]:
+            return True
+        return False
+    monkeypatch.setattr(MOCK_OS_PATH_ISDIR, mock.Mock(side_effect=mock_isdir_logic))
+
+    # Mock os.listdir to return no stories by default to simplify tests not focused on story processing loop
+    monkeypatch.setattr(MOCK_OS_LISTDIR, mock.Mock(return_value=[]))
+
+    # Mock click.echo to check output
+    mock_echo = mock.Mock()
+    monkeypatch.setattr(MOCK_CLICK_ECHO_PATH, mock_echo)
+
+    # Mock logger
+    mock_logger_instance = mock.Mock(spec_set=["info", "warning", "error", "debug"])
+    monkeypatch.setattr(MOCK_LOGGER_PATH, mock_logger_instance)
+
+
+    return {
+        "config_manager": mock_cm_instance,
+        "gdrive_sync": mock_gdrive_sync_instance,
+        "logger": mock_logger_instance,
+        "click_echo": mock_echo,
+        "os_path_exists_mock": monkeypatch.getattr(MOCK_OS_PATH_EXISTS) # Return this if needed for modification
+    }
+
+
+def test_cloud_backup_handler_uploads_html_report_if_exists(mock_cloud_backup_common_deps, monkeypatch):
+    """Test HTML report is uploaded if it exists."""
+    mock_gdrive_sync = mock_cloud_backup_common_deps["gdrive_sync"]
+    mock_logger = mock_cloud_backup_common_deps["logger"]
+    mock_click_echo = mock_cloud_backup_common_deps["click_echo"]
+
+    report_path = "/mocked/workspace/reports/archive_report.html"
+    # Ensure os.path.exists returns True only for the report path in this test's context
+    monkeypatch.setattr(MOCK_OS_PATH_EXISTS, lambda path: path == report_path)
+
+    # Call the handler
+    cloud_backup_handler(
+        story_id=None,
+        cloud_service_name='gdrive',
+        force_full_upload=False,
+        gdrive_credentials_path='dummy_creds.json',
+        gdrive_token_path='dummy_token.json'
+    )
+
+    # Assert upload_file was called for the report
+    mock_gdrive_sync.upload_file.assert_called_once_with(
+        local_file_path=report_path,
+        remote_folder_id="dummy_root_folder_id",
+        remote_file_name="archive_report.html"
+    )
+
+    mock_logger.info.assert_any_call(f"Checking for HTML report at: {report_path}")
+    mock_logger.info.assert_any_call("Attempting to upload HTML report...")
+    mock_logger.info.assert_any_call(f"Uploading report '{report_path}' to cloud folder ID 'dummy_root_folder_id'.")
+    assert any("Successfully uploaded HTML report" in str(call_args) for call_args in mock_click_echo.call_args_list)
+
+
+def test_cloud_backup_handler_skips_html_report_if_not_exists(mock_cloud_backup_common_deps, monkeypatch):
+    """Test HTML report is skipped if it does not exist."""
+    mock_gdrive_sync = mock_cloud_backup_common_deps["gdrive_sync"]
+    mock_logger = mock_cloud_backup_common_deps["logger"]
+    mock_click_echo = mock_cloud_backup_common_deps["click_echo"]
+
+    report_path = "/mocked/workspace/reports/archive_report.html"
+    monkeypatch.setattr(MOCK_OS_PATH_EXISTS, lambda path: path != report_path and path != 'dummy_creds.json' and path != 'dummy_token.json')
+
+
+    cloud_backup_handler(
+        story_id=None,
+        cloud_service_name='gdrive',
+        force_full_upload=False,
+        gdrive_credentials_path='dummy_creds.json',
+        gdrive_token_path='dummy_token.json'
+    )
+
+    mock_gdrive_sync.upload_file.assert_not_called()
+    mock_logger.info.assert_any_call(f"HTML report not found at {report_path}, skipping upload.")
+    assert any(f"HTML report not found at {report_path}, skipping upload." in str(call_args) for call_args in mock_click_echo.call_args_list)
+
+
+def test_cloud_backup_handler_handles_report_upload_failure(mock_cloud_backup_common_deps, monkeypatch):
+    """Test graceful handling of report upload failure."""
+    mock_gdrive_sync = mock_cloud_backup_common_deps["gdrive_sync"]
+    mock_logger = mock_cloud_backup_common_deps["logger"]
+    mock_click_echo = mock_cloud_backup_common_deps["click_echo"]
+
+    report_path = "/mocked/workspace/reports/archive_report.html"
+    monkeypatch.setattr(MOCK_OS_PATH_EXISTS, lambda path: path == report_path)
+
+    mock_gdrive_sync.upload_file.side_effect = ConnectionError("Simulated upload error")
+
+    cloud_backup_handler(
+        story_id=None,
+        cloud_service_name='gdrive',
+        force_full_upload=False,
+        gdrive_credentials_path='dummy_creds.json',
+        gdrive_token_path='dummy_token.json'
+    )
+
+    mock_gdrive_sync.upload_file.assert_called_once_with(
+        local_file_path=report_path,
+        remote_folder_id="dummy_root_folder_id",
+        remote_file_name="archive_report.html"
+    )
+
+    mock_logger.error.assert_any_call("Connection error during HTML report upload: Simulated upload error", exc_info=True)
+    assert any("Error uploading HTML report: Simulated upload error" in str(call_args) for call_args in mock_click_echo.call_args_list)
+
+
+def test_cloud_backup_uses_existing_cloud_base_id_for_report(mock_cloud_backup_common_deps, monkeypatch):
+    """Test report uses cloud_base_folder_id set during story processing."""
+    mock_gdrive_sync = mock_cloud_backup_common_deps["gdrive_sync"]
+    mock_logger = mock_cloud_backup_common_deps["logger"]
+
+    # Simulate one story being processed
+    monkeypatch.setattr(MOCK_OS_LISTDIR, mock.Mock(return_value=["story1"]))
+
+    # Mock GDriveSync's create_folder_if_not_exists for story processing
+    # First call for base "Webnovel Archiver Backups", second for "story1" folder
+    # This first call's return value should be used by the report logic later.
+    mock_gdrive_sync.create_folder_if_not_exists.side_effect = [
+        "story_proc_root_id", # ID for "Webnovel Archiver Backups"
+        "story1_folder_id"    # ID for "story1"
+    ]
+    # Mock get_file_metadata to make story file appear non-existent or older, forcing upload attempt
+    mock_gdrive_sync.get_file_metadata.return_value = None
+
+    report_path = "/mocked/workspace/reports/archive_report.html"
+    story_progress_file = "/mocked/workspace/archival_status/story1/progress_status.json"
+
+    # os.path.exists needs to return True for:
+    # - report_path
+    # - story_progress_file (to enter the story processing block)
+    # - gdrive_credentials_path / gdrive_token_path (if they are checked by GDriveSync init, though GDriveSync itself is mocked)
+    # For simplicity, we assume GDriveSync init doesn't hit os.path.exists for creds/token in this unit test context.
+    def selective_os_path_exists(path_to_check):
+        if path_to_check == report_path: return True
+        if path_to_check == story_progress_file: return True
+        if path_to_check == 'dummy_creds.json': return True # Added to handle GDriveSync init if it checks
+        if path_to_check == 'dummy_token.json': return True # Added
+        return False
+    monkeypatch.setattr(MOCK_OS_PATH_EXISTS, mock.Mock(side_effect=selective_os_path_exists))
+
+    cloud_backup_handler(
+        story_id=None,
+        cloud_service_name='gdrive',
+        force_full_upload=True, # Force story file upload to simplify mocking
+        gdrive_credentials_path='dummy_creds.json',
+        gdrive_token_path='dummy_token.json'
+    )
+
+    # Check calls to upload_file
+    # Expected: one for story1's progress_status.json, one for archive_report.html
+    report_upload_call_args = None
+    story_file_upload_call_args = None
+
+    for call_args_tuple in mock_gdrive_sync.upload_file.call_args_list:
+        kwargs = call_args_tuple.kwargs
+        if kwargs.get('remote_file_name') == "archive_report.html":
+            report_upload_call_args = kwargs
+        elif kwargs.get('remote_file_name') == "progress_status.json": # Name used in handler
+            story_file_upload_call_args = kwargs
+
+    assert story_file_upload_call_args is not None, "progress_status.json for story1 was not uploaded"
+    assert story_file_upload_call_args['remote_folder_id'] == "story1_folder_id"
+
+    assert report_upload_call_args is not None, "archive_report.html was not uploaded"
+    assert report_upload_call_args['local_file_path'] == report_path
+    assert report_upload_call_args['remote_folder_id'] == "story_proc_root_id" # Key assertion
+
+    # Verify create_folder_if_not_exists was called for "Webnovel Archiver Backups" only ONCE
+    base_folder_creation_calls = [
+        args for args, kwargs in mock_gdrive_sync.create_folder_if_not_exists.call_args_list
+        if args[0] == "Webnovel Archiver Backups"
+    ]
+    assert len(base_folder_creation_calls) == 1, \
+        "create_folder_if_not_exists for 'Webnovel Archiver Backups' should only be called once (during story processing)"
+
+    mock_logger.info.assert_any_call(f"Uploading report '{report_path}' to cloud folder ID 'story_proc_root_id'.")


### PR DESCRIPTION
This commit introduces the functionality to upload the generated HTML report (`archive_report.html`) during the `cloud-backup` process.

Modifications:
- The `cloud_backup_handler` in `webnovel_archiver/cli/handlers.py` has been updated.
- After processing all individual stories, the handler now checks for the existence of `reports/archive_report.html` within the workspace.
- If found, the report is uploaded to the root of the "Webnovel Archiver Backups" folder in the configured cloud storage (e.g., Google Drive).
- Appropriate logging and messages have been added to indicate the status of the report upload (attempting, success, failure, or skipped if not found).
- Error handling has been included to ensure that any issues during the report upload do not halt the entire backup operation.

Testing:
- Unit tests have been added to `tests/cli/test_handlers.py`.
- These tests cover scenarios including:
    - Report exists and is successfully uploaded.
    - Report does not exist and the upload is skipped.
    - Report exists but the upload fails (e.g., due to a connection error).
    - Report upload correctly uses an existing cloud base folder ID if it was established during story backup.
- Mocks were used for cloud services and file system operations to ensure tests are isolated and repeatable.