### PR TITLE
Fix: Correct Phase 1 migration logic for timestamps

### DIFF
--- a/webnovel_archiver/core/storage/progress_manager.py
+++ b/webnovel_archiver/core/storage/progress_manager.py
@@ -114,6 +114,14 @@ def load_progress(story_id: str, workspace_root: str = DEFAULT_WORKSPACE_ROOT) -
             if migration_required:
                 logger.info(f"Migrating progress file for story '{story_id}' at {filepath} to new format with status fields in chapters.")
 
+                # Get file modification time for chapter timestamps
+                file_mod_time_iso = "N/A"
+                try:
+                    mtime = os.path.getmtime(filepath)
+                    file_mod_time_iso = datetime.datetime.fromtimestamp(mtime, datetime.timezone.utc).isoformat()
+                except OSError as e:
+                    logger.warning(f"Could not retrieve modification time for progress file {filepath} during migration. Using 'N/A' for timestamps. Error: {e}")
+
                 backup_filepath = filepath + ".bak"
                 try:
                     import shutil # Import here for focused change, though top-level is conventional
@@ -129,8 +137,8 @@ def load_progress(story_id: str, workspace_root: str = DEFAULT_WORKSPACE_ROOT) -
                         if isinstance(chapter, dict): # Process only if chapter is a dictionary
                             chapter_copy = chapter.copy()
                             chapter_copy["status"] = "active"
-                            chapter_copy["first_seen_on"] = "N/A"
-                            chapter_copy["last_checked_on"] = "N/A"
+                            chapter_copy["first_seen_on"] = file_mod_time_iso
+                            chapter_copy["last_checked_on"] = file_mod_time_iso
                             migrated_chapters_list.append(chapter_copy)
                         else:
                             logger.warning(f"Skipping non-dict chapter entry during migration for story '{story_id}' in {filepath}: {chapter}")


### PR DESCRIPTION
The migration logic in `webnovel_archiver/core/storage/progress_manager.py` was updated to correctly implement the requirements of Phase 1 of the status.md development plan.

Previously, migrated chapters had `first_seen_on` and `last_checked_on` fields set to "N/A". This change modifies the `load_progress` function to:

- Retrieve the last modification timestamp of the existing progress file.
- Use this timestamp (in ISO 8601 format) for `first_seen_on` and `last_checked_on` fields in migrated chapters.
- Fall back to "N/A" and log a warning if the file modification timestamp cannot be obtained.

The unit tests in `tests/core/storage/test_progress_manager.py` were also updated:
- `test_load_progress_migration_old_format_single_chapter` now explicitly sets and verifies the file modification timestamp.
- A new test, `test_load_progress_migration_os_error_getmtime`, was added to ensure correct behavior (fallback to "N/A" and logging) when `os.path.getmtime` fails.

These changes ensure that migrated data more accurately reflects the specifications of the development plan, providing a better foundation for subsequent development phases.