### PR TITLE
feat: Automatically open report in browser

### DIFF
--- a/test_workspace/reports/archive_report.html
+++ b/test_workspace/reports/archive_report.html
@@ -204,7 +204,7 @@
     </div>
 
         <div id="storyListContainer">
-    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Unknown (No chapters downloaded, total unknown)" data-last-updated="" data-progress="0">
+    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Complete" data-last-updated="" data-progress="0">
         <div class="story-card-summary">
             <div class="story-cover">
                 <img src="https://via.placeholder.com/150x220.png?text=No+Cover" alt="Cover for Untitled">
@@ -225,8 +225,10 @@
             <div class="progress-bar-container">
                 <div class="progress-bar" style="width:0%;">0%</div>
             </div>
-            <p>0 chapters (total unknown)</p>
-            <p><strong>Story Status:</strong> <span class="badge status-unknown-no-chapters-downloaded-total-unknown">Unknown (No chapters downloaded, total unknown)</span></p>
+            <p>0 / 0 chapters downloaded</p>
+            <p><strong>Story Status:</strong> <span class="badge status-complete">Complete</span></p>
+
+            <p class="section-title">Chapters:</p><p class="no-items">No chapter details available.</p>
 
             <p class="section-title">Local EPUBs (Generated: N/A):</p>
             <p class="no-items">No EPUB files found.</p>
@@ -243,7 +245,7 @@
         </div>
     </div>
 
-    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Unknown (No chapters downloaded, total unknown)" data-last-updated="" data-progress="0">
+    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Complete" data-last-updated="" data-progress="0">
         <div class="story-card-summary">
             <div class="story-cover">
                 <img src="https://via.placeholder.com/150x220.png?text=No+Cover" alt="Cover for Untitled">
@@ -264,8 +266,10 @@
             <div class="progress-bar-container">
                 <div class="progress-bar" style="width:0%;">0%</div>
             </div>
-            <p>0 chapters (total unknown)</p>
-            <p><strong>Story Status:</strong> <span class="badge status-unknown-no-chapters-downloaded-total-unknown">Unknown (No chapters downloaded, total unknown)</span></p>
+            <p>0 / 0 chapters downloaded</p>
+            <p><strong>Story Status:</strong> <span class="badge status-complete">Complete</span></p>
+
+            <p class="section-title">Chapters:</p><p class="no-items">No chapter details available.</p>
 
             <p class="section-title">Local EPUBs (Generated: N/A):</p>
             <p class="no-items">No EPUB files found.</p>
@@ -282,7 +286,7 @@
         </div>
     </div>
 
-    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Unknown (No chapters downloaded, total unknown)" data-last-updated="" data-progress="0">
+    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Complete" data-last-updated="" data-progress="0">
         <div class="story-card-summary">
             <div class="story-cover">
                 <img src="https://via.placeholder.com/150x220.png?text=No+Cover" alt="Cover for Untitled">
@@ -303,8 +307,10 @@
             <div class="progress-bar-container">
                 <div class="progress-bar" style="width:0%;">0%</div>
             </div>
-            <p>0 chapters (total unknown)</p>
-            <p><strong>Story Status:</strong> <span class="badge status-unknown-no-chapters-downloaded-total-unknown">Unknown (No chapters downloaded, total unknown)</span></p>
+            <p>0 / 0 chapters downloaded</p>
+            <p><strong>Story Status:</strong> <span class="badge status-complete">Complete</span></p>
+
+            <p class="section-title">Chapters:</p><p class="no-items">No chapter details available.</p>
 
             <p class="section-title">Local EPUBs (Generated: N/A):</p>
             <p class="no-items">No EPUB files found.</p>
@@ -321,7 +327,7 @@
         </div>
     </div>
 
-    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Unknown (No chapters downloaded, total unknown)" data-last-updated="" data-progress="0">
+    <div class="story-card" data-title="Untitled" data-author="Unknown Author" data-status="Complete" data-last-updated="" data-progress="0">
         <div class="story-card-summary">
             <div class="story-cover">
                 <img src="https://via.placeholder.com/150x220.png?text=No+Cover" alt="Cover for Untitled">
@@ -342,8 +348,10 @@
             <div class="progress-bar-container">
                 <div class="progress-bar" style="width:0%;">0%</div>
             </div>
-            <p>0 chapters (total unknown)</p>
-            <p><strong>Story Status:</strong> <span class="badge status-unknown-no-chapters-downloaded-total-unknown">Unknown (No chapters downloaded, total unknown)</span></p>
+            <p>0 / 0 chapters downloaded</p>
+            <p><strong>Story Status:</strong> <span class="badge status-complete">Complete</span></p>
+
+            <p class="section-title">Chapters:</p><p class="no-items">No chapter details available.</p>
 
             <p class="section-title">Local EPUBs (Generated: N/A):</p>
             <p class="no-items">No EPUB files found.</p>

--- a/webnovel_archiver/generate_report.py
+++ b/webnovel_archiver/generate_report.py
@@ -4,6 +4,7 @@ import datetime
 import sys
 import re
 import html # For escaping HTML content
+import webbrowser # Added to open the report in a browser
 
 # Adjust path to import sibling modules
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -689,6 +690,12 @@ def main():
                 f.write(final_html)
             logger.info(f"Successfully wrote HTML report to: {report_html_path}")
             print(f"HTML report generated: {report_html_path}")
+            try:
+                webbrowser.open_new_tab(f"file:///{os.path.abspath(report_html_path)}")
+                logger.info(f"Attempted to open HTML report in browser: {report_html_path}")
+            except Exception as e_browser:
+                logger.error(f"Failed to open report in browser: {e_browser}", exc_info=True)
+                print(f"Note: Could not open report in browser. Error: {e_browser}")
         except IOError as e: # More specific exception for file I/O
             logger.error(f"Failed to write HTML report due to IOError {report_html_path}: {e}", exc_info=True)
             print(f"Error: Could not write HTML report to {report_html_path}. Check logs for details.")


### PR DESCRIPTION
This commit introduces two main changes:

1.  Modifies the `generate-report` command to automatically open the generated HTML report in the user's default web browser. This uses the `webbrowser` module and ensures the correct absolute file path is used. Error handling is included in case the browser cannot be opened.

2.  Updates `ConfigManager` to prioritize the `WNA_WORKSPACE_ROOT` environment variable for determining the workspace path. If the environment variable is set, it will be used; otherwise, the system falls back to the path specified in `settings.ini` or the default path. This was necessary to ensure testability and correct behavior of the report generation path when the environment variable is used.