### PR TITLE
Implement selective cloud backup based on modification status

### DIFF
--- a/webnovel_archiver/core/orchestrator.py
+++ b/webnovel_archiver/core/orchestrator.py
@@ -526,8 +526,10 @@ def archive_story(
     # 6. Save Final Progress
     logger.info("Saving final progress status...")
     try:
+        # Update last_archived_timestamp before final save
+        progress_data["last_archived_timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
         save_progress(s_id, progress_data, workspace_root)
-        logger.info(f"Progress saved to {os.path.join(workspace_root, ARCHIVAL_STATUS_DIR, s_id, 'progress_status.json')}")
+        logger.info(f"Progress saved (including last_archived_timestamp) to {os.path.join(workspace_root, ARCHIVAL_STATUS_DIR, s_id, 'progress_status.json')}")
     except Exception as e:
         logger.error(f"Error saving progress for story ID {s_id}: {e}")
 


### PR DESCRIPTION
This change refactors the cloud backup functionality to be more efficient.

Key changes:
- Added `last_archived_timestamp` to `progress_status.json`.
- `archive_story` now updates `last_archived_timestamp` upon successful completion.
- `cloud_backup_handler` now checks `last_archived_timestamp` against `last_successful_backup_timestamp` (from `cloud_backup_status`) to determine if a story's files need to be backed up.
- Backup is skipped if the story hasn't been modified since its last successful backup, unless `--force-full-upload` is used.
- `progress_status.json` is updated accurately after backup attempts to reflect the operation's outcome, including whether a new successful backup occurred.