### PR TITLE
Centralize path management into PathManager class

### DIFF
--- a/webnovel_archiver/core/path_manager.py
+++ b/webnovel_archiver/core/path_manager.py
@@ -1,0 +1,105 @@
+import os
+
+class PathManager:
+    """
+    Manages the construction of file and directory paths for a story's workspace.
+    """
+    RAW_CONTENT_DIR_NAME = "raw_content"
+    PROCESSED_CONTENT_DIR_NAME = "processed_content"
+    EBOOKS_DIR_NAME = "ebooks"
+    ARCHIVAL_STATUS_DIR_NAME = "archival_status"
+    TEMP_COVER_DIR_NAME = "temp_cover_images" # Subdirectory within EBOOKS_DIR_NAME/story_id
+    PROGRESS_FILENAME = "progress_status.json"
+
+    def __init__(self, workspace_root: str, story_id: str):
+        """
+        Initializes PathManager with the root of the workspace and the story ID.
+
+        Args:
+            workspace_root: The absolute or relative path to the workspace directory.
+            story_id: The unique identifier for the story.
+        """
+        if not workspace_root:
+            raise ValueError("workspace_root cannot be empty.")
+        if not story_id:
+            raise ValueError("story_id cannot be empty.")
+
+        self._workspace_root = workspace_root
+        self._story_id = story_id
+
+    def get_workspace_root(self) -> str:
+        """Returns the workspace root path."""
+        return self._workspace_root
+
+    def get_story_id(self) -> str:
+        """Returns the story ID."""
+        return self._story_id
+
+    # Raw Content Paths
+    def get_raw_content_story_dir(self) -> str:
+        """Returns the path to the raw content directory for the story."""
+        return os.path.join(self._workspace_root, self.RAW_CONTENT_DIR_NAME, self._story_id)
+
+    def get_raw_content_chapter_filepath(self, raw_filename: str) -> str:
+        """Returns the full path to a specific raw chapter file."""
+        if not raw_filename:
+            raise ValueError("raw_filename cannot be empty.")
+        return os.path.join(self.get_raw_content_story_dir(), raw_filename)
+
+    # Processed Content Paths
+    def get_processed_content_story_dir(self) -> str:
+        """Returns the path to the processed content directory for the story."""
+        return os.path.join(self._workspace_root, self.PROCESSED_CONTENT_DIR_NAME, self._story_id)
+
+    def get_processed_content_chapter_filepath(self, processed_filename: str) -> str:
+        """Returns the full path to a specific processed chapter file."""
+        if not processed_filename:
+            raise ValueError("processed_filename cannot be empty.")
+        return os.path.join(self.get_processed_content_story_dir(), processed_filename)
+
+    # Archival Status Paths
+    def get_archival_status_story_dir(self) -> str:
+        """Returns the path to the archival status directory for the story."""
+        return os.path.join(self._workspace_root, self.ARCHIVAL_STATUS_DIR_NAME, self._story_id)
+
+    def get_progress_filepath(self) -> str:
+        """Returns the full path to the progress status file for the story."""
+        return os.path.join(self.get_archival_status_story_dir(), self.PROGRESS_FILENAME)
+
+    # Ebooks and Cover Paths
+    def get_ebooks_story_dir(self) -> str:
+        """Returns the path to the ebooks directory for the story."""
+        return os.path.join(self._workspace_root, self.EBOOKS_DIR_NAME, self._story_id)
+
+    def get_epub_filepath(self, epub_filename: str) -> str:
+        """Returns the full path to a specific EPUB file."""
+        if not epub_filename:
+            raise ValueError("epub_filename cannot be empty.")
+        return os.path.join(self.get_ebooks_story_dir(), epub_filename)
+
+    def get_temp_cover_story_dir(self) -> str:
+        """
+        Returns the path to the temporary cover images directory for the story.
+        This is a subdirectory within the story's ebook directory.
+        """
+        return os.path.join(self.get_ebooks_story_dir(), self.TEMP_COVER_DIR_NAME)
+
+    def get_cover_image_filepath(self, cover_filename: str) -> str:
+        """
+        Returns the full path to a specific cover image file within the temp cover directory.
+        """
+        if not cover_filename:
+            raise ValueError("cover_filename cannot be empty.")
+        return os.path.join(self.get_temp_cover_story_dir(), cover_filename)
+
+    # Generic directory getter for base directories (raw, processed, ebooks, archival_status)
+    def get_base_directory(self, dir_type: str) -> str:
+        """
+        Returns the path to a base directory type within the workspace root.
+        Example: get_base_directory(PathManager.RAW_CONTENT_DIR_NAME)
+                 returns workspace_root/raw_content
+        """
+        if dir_type not in [self.RAW_CONTENT_DIR_NAME, self.PROCESSED_CONTENT_DIR_NAME,
+                            self.EBOOKS_DIR_NAME, self.ARCHIVAL_STATUS_DIR_NAME]:
+            raise ValueError(f"Invalid directory type: {dir_type}")
+        return os.path.join(self._workspace_root, dir_type)

--- a/webnovel_archiver/generate_report.py
+++ b/webnovel_archiver/generate_report.py
@@ -11,7 +11,9 @@ PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, PROJECT_ROOT)
 
 from webnovel_archiver.core.config_manager import ConfigManager
-from webnovel_archiver.core.storage.progress_manager import load_progress, DEFAULT_WORKSPACE_ROOT, ARCHIVAL_STATUS_DIR, EBOOKS_DIR, get_epub_file_details
+from webnovel_archiver.core.storage.progress_manager import load_progress, get_epub_file_details # Removed constants
+# from webnovel_archiver.core.path_manager import PathManager # For ARCHIVAL_STATUS_DIR_NAME
+from webnovel_archiver.core.path_manager import PathManager # Import PathManager to access its constants
 from webnovel_archiver.utils.logger import get_logger
 
 # Initialize logger
@@ -570,8 +572,8 @@ def main():
             logger.error("Workspace root could not be determined. Exiting.")
             return
 
-        archival_status_path = os.path.join(workspace_root, ARCHIVAL_STATUS_DIR)
-        reports_dir = os.path.join(workspace_root, "reports")
+        archival_status_path = os.path.join(workspace_root, PathManager.ARCHIVAL_STATUS_DIR_NAME) # Use PathManager constant
+        reports_dir = os.path.join(workspace_root, "reports") # This can remain as "reports" is a direct subdir for this script's output
 
         # Create reports directory if it doesn't exist
         os.makedirs(reports_dir, exist_ok=True)

--- a/webnovel_archiver/tests/core/test_path_manager.py
+++ b/webnovel_archiver/tests/core/test_path_manager.py
@@ -1,0 +1,89 @@
+import unittest
+import os
+from webnovel_archiver.core.path_manager import PathManager
+
+class TestPathManager(unittest.TestCase):
+
+    def setUp(self):
+        self.workspace_root = "test_workspace"
+        self.story_id = "test_story_123"
+        self.pm = PathManager(self.workspace_root, self.story_id)
+
+    def test_initialization(self):
+        self.assertEqual(self.pm.get_workspace_root(), self.workspace_root)
+        self.assertEqual(self.pm.get_story_id(), self.story_id)
+        with self.assertRaises(ValueError):
+            PathManager("", "some_id")
+        with self.assertRaises(ValueError):
+            PathManager("some_root", "")
+
+    def test_get_raw_content_story_dir(self):
+        expected = os.path.join(self.workspace_root, PathManager.RAW_CONTENT_DIR_NAME, self.story_id)
+        self.assertEqual(self.pm.get_raw_content_story_dir(), expected)
+
+    def test_get_raw_content_chapter_filepath(self):
+        filename = "chapter_raw.html"
+        expected = os.path.join(self.workspace_root, PathManager.RAW_CONTENT_DIR_NAME, self.story_id, filename)
+        self.assertEqual(self.pm.get_raw_content_chapter_filepath(filename), expected)
+        with self.assertRaises(ValueError):
+            self.pm.get_raw_content_chapter_filepath("")
+
+    def test_get_processed_content_story_dir(self):
+        expected = os.path.join(self.workspace_root, PathManager.PROCESSED_CONTENT_DIR_NAME, self.story_id)
+        self.assertEqual(self.pm.get_processed_content_story_dir(), expected)
+
+    def test_get_processed_content_chapter_filepath(self):
+        filename = "chapter_processed.html"
+        expected = os.path.join(self.workspace_root, PathManager.PROCESSED_CONTENT_DIR_NAME, self.story_id, filename)
+        self.assertEqual(self.pm.get_processed_content_chapter_filepath(filename), expected)
+        with self.assertRaises(ValueError):
+            self.pm.get_processed_content_chapter_filepath("")
+
+    def test_get_archival_status_story_dir(self):
+        expected = os.path.join(self.workspace_root, PathManager.ARCHIVAL_STATUS_DIR_NAME, self.story_id)
+        self.assertEqual(self.pm.get_archival_status_story_dir(), expected)
+
+    def test_get_progress_filepath(self):
+        expected = os.path.join(self.workspace_root, PathManager.ARCHIVAL_STATUS_DIR_NAME, self.story_id, PathManager.PROGRESS_FILENAME)
+        self.assertEqual(self.pm.get_progress_filepath(), expected)
+
+    def test_get_ebooks_story_dir(self):
+        expected = os.path.join(self.workspace_root, PathManager.EBOOKS_DIR_NAME, self.story_id)
+        self.assertEqual(self.pm.get_ebooks_story_dir(), expected)
+
+    def test_get_epub_filepath(self):
+        filename = "story.epub"
+        expected = os.path.join(self.workspace_root, PathManager.EBOOKS_DIR_NAME, self.story_id, filename)
+        self.assertEqual(self.pm.get_epub_filepath(filename), expected)
+        with self.assertRaises(ValueError):
+            self.pm.get_epub_filepath("")
+
+    def test_get_temp_cover_story_dir(self):
+        expected = os.path.join(self.workspace_root, PathManager.EBOOKS_DIR_NAME, self.story_id, PathManager.TEMP_COVER_DIR_NAME)
+        self.assertEqual(self.pm.get_temp_cover_story_dir(), expected)
+
+    def test_get_cover_image_filepath(self):
+        filename = "cover.jpg"
+        expected = os.path.join(self.workspace_root, PathManager.EBOOKS_DIR_NAME, self.story_id, PathManager.TEMP_COVER_DIR_NAME, filename)
+        self.assertEqual(self.pm.get_cover_image_filepath(filename), expected)
+        with self.assertRaises(ValueError):
+            self.pm.get_cover_image_filepath("")
+
+    def test_get_base_directory(self):
+        expected_raw = os.path.join(self.workspace_root, PathManager.RAW_CONTENT_DIR_NAME)
+        self.assertEqual(self.pm.get_base_directory(PathManager.RAW_CONTENT_DIR_NAME), expected_raw)
+
+        expected_processed = os.path.join(self.workspace_root, PathManager.PROCESSED_CONTENT_DIR_NAME)
+        self.assertEqual(self.pm.get_base_directory(PathManager.PROCESSED_CONTENT_DIR_NAME), expected_processed)
+
+        expected_ebooks = os.path.join(self.workspace_root, PathManager.EBOOKS_DIR_NAME)
+        self.assertEqual(self.pm.get_base_directory(PathManager.EBOOKS_DIR_NAME), expected_ebooks)
+
+        expected_archival = os.path.join(self.workspace_root, PathManager.ARCHIVAL_STATUS_DIR_NAME)
+        self.assertEqual(self.pm.get_base_directory(PathManager.ARCHIVAL_STATUS_DIR_NAME), expected_archival)
+
+        with self.assertRaises(ValueError):
+            self.pm.get_base_directory("invalid_dir_type")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Created PathManager in core/path_manager.py to handle all workspace path constructions.
- Added unit tests for PathManager.
- Refactored Orchestrator, EPUBGenerator, and ProgressManager to use PathManager.
- Updated generate_report.py to use PathManager constants for directory names.
- Ensured workspace_root is explicitly passed where needed after removal of DEFAULT_WORKSPACE_ROOT from ProgressManager.