### PR TITLE
feat: Implement FetcherFactory for dynamic fetcher selection

### DIFF
--- a/tests/core/fetchers/test_fetcher_factory.py
+++ b/tests/core/fetchers/test_fetcher_factory.py
@@ -1,0 +1,83 @@
+import unittest
+from urllib.parse import urlparse
+
+from webnovel_archiver.core.fetchers.fetcher_factory import FetcherFactory
+from webnovel_archiver.core.fetchers.royalroad_fetcher import RoyalRoadFetcher
+from webnovel_archiver.core.fetchers.base_fetcher import BaseFetcher
+from webnovel_archiver.core.fetchers.exceptions import UnsupportedSourceError
+
+
+class TestFetcherFactory(unittest.TestCase):
+
+    def test_get_fetcher_royalroad_url(self):
+        """Test that a RoyalRoadFetcher is returned for a RoyalRoad URL."""
+        urls = [
+            "https://www.royalroad.com/fiction/12345/some-story",
+            "http://royalroad.com/another/story",
+            "https://royalroad.com/fiction/short",
+            "https://www.royalroad.com/f/123/a-story" # Example of a different path structure
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                fetcher = FetcherFactory.get_fetcher(url)
+                self.assertIsInstance(fetcher, RoyalRoadFetcher)
+                self.assertIsInstance(fetcher, BaseFetcher)
+
+    def test_get_fetcher_unsupported_url(self):
+        """Test that UnsupportedSourceError is raised for unsupported domains."""
+        urls = [
+            "https://www.scribblehub.com/series/123/a-scribble-story",
+            "http://unsupported-domain.com/fiction/story",
+            "https://www.another-random-site.org/novel/chapter1"
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                with self.assertRaises(UnsupportedSourceError) as context:
+                    FetcherFactory.get_fetcher(url)
+                self.assertIn("Source not supported for URL", str(context.exception))
+                self.assertIn(urlparse(url).netloc.lower(), str(context.exception))
+
+
+    def test_get_fetcher_malformed_url_value_error(self):
+        """Test that ValueError is raised for malformed or invalid URLs."""
+        urls = [
+            "just_a_string_not_a_url", # Not a valid URL structure
+            "ftp://validprotocolbutunsupported.com/story", # Valid URL, but factory might raise UnsupportedSourceError first depending on logic
+                                                       # Current factory logic will pass to urlparse, then fail on domain check.
+                                                       # This test is more about the structure if urlparse itself failed or returned no domain
+            "http:///missingdomain.com", # malformed
+        ]
+        for url in urls:
+            with self.subTest(url=url):
+                # Depending on the exact nature of malformation, urlparse might still return something.
+                # The factory's check `if not domain:` is key here for some cases.
+                # "just_a_string_not_a_url" will likely have no netloc.
+                if "ftp://" in url: # FTP is a valid scheme, so it will be an UnsupportedSourceError
+                    with self.assertRaises(UnsupportedSourceError):
+                        FetcherFactory.get_fetcher(url)
+                else:
+                    with self.assertRaises(ValueError) as context:
+                        FetcherFactory.get_fetcher(url)
+                    self.assertTrue(
+                        "Invalid URL format" in str(context.exception) or \
+                        "Could not determine domain" in str(context.exception)
+                    )
+
+
+    def test_get_fetcher_empty_url_value_error(self):
+        """Test that ValueError is raised for an empty URL string."""
+        with self.assertRaises(ValueError) as context:
+            FetcherFactory.get_fetcher("")
+        self.assertIn("Story URL cannot be empty", str(context.exception))
+
+    def test_get_fetcher_url_without_domain_value_error(self):
+        """Test that ValueError is raised for a URL parsed with no domain."""
+        # urlparse on "path/only" results in scheme='', netloc='', path='path/only'
+        url = "/path/only/no/domain"
+        with self.assertRaises(ValueError) as context:
+            FetcherFactory.get_fetcher(url)
+        self.assertIn("Could not determine domain from URL", str(context.exception))
+        self.assertIn(url, str(context.exception))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/webnovel_archiver/core/fetchers/__init__.py
+++ b/webnovel_archiver/core/fetchers/__init__.py
@@ -1,0 +1,13 @@
+from .base_fetcher import BaseFetcher, StoryMetadata, ChapterInfo
+from .royalroad_fetcher import RoyalRoadFetcher
+from .fetcher_factory import FetcherFactory
+from .exceptions import UnsupportedSourceError
+
+__all__ = [
+    "BaseFetcher",
+    "StoryMetadata",
+    "ChapterInfo",
+    "RoyalRoadFetcher",
+    "FetcherFactory",
+    "UnsupportedSourceError",
+]

--- a/webnovel_archiver/core/fetchers/exceptions.py
+++ b/webnovel_archiver/core/fetchers/exceptions.py
@@ -1,0 +1,3 @@
+class UnsupportedSourceError(Exception):
+    """Custom exception for unsupported story sources."""
+    pass

--- a/webnovel_archiver/core/fetchers/fetcher_factory.py
+++ b/webnovel_archiver/core/fetchers/fetcher_factory.py
@@ -1,0 +1,79 @@
+from urllib.parse import urlparse
+
+from .base_fetcher import BaseFetcher
+from .royalroad_fetcher import RoyalRoadFetcher
+from .exceptions import UnsupportedSourceError
+
+
+class FetcherFactory:
+    """
+    Factory class to select and return the appropriate fetcher based on the story URL.
+    """
+
+    @staticmethod
+    def get_fetcher(story_url: str) -> BaseFetcher:
+        """
+        Analyzes the story URL and returns an instance of the appropriate fetcher.
+
+        Args:
+            story_url: The URL of the story.
+
+        Returns:
+            An instance of a BaseFetcher subclass.
+
+        Raises:
+            UnsupportedSourceError: If the domain of the story_url is not supported.
+            ValueError: If the URL is malformed or missing a domain.
+        """
+        if not story_url:
+            raise ValueError("Story URL cannot be empty.")
+
+        try:
+            parsed_url = urlparse(story_url)
+            domain = parsed_url.netloc.lower()
+        except Exception as e: # Catch any parsing errors, though urlparse is usually robust
+            raise ValueError(f"Invalid URL format: {story_url}. Error: {e}")
+
+        if not domain:
+            raise ValueError(f"Could not determine domain from URL: {story_url}")
+
+        if "royalroad.com" in domain:
+            return RoyalRoadFetcher()
+        # Example for a future ScribbleHubFetcher
+        # elif "scribblehub.com" in domain:
+        #     from .scribblehub_fetcher import ScribbleHubFetcher # Assuming it exists
+        #     return ScribbleHubFetcher()
+        else:
+            raise UnsupportedSourceError(f"Source not supported for URL: {story_url} (domain: {domain})")
+
+if __name__ == '__main__':
+    # Example Usage (for testing or demonstration)
+    test_urls = [
+        "https://www.royalroad.com/fiction/12345/some-story",
+        "http://royalroad.com/another/story",
+        "https://www.scribblehub.com/series/123/a-scribble-story", # Will raise UnsupportedSourceError
+        "https://unsupported.com/fiction/789", # Will raise UnsupportedSourceError
+        "ftp://invalidprotocol.com/story", # Will raise UnsupportedSourceError
+        "just_a_string_not_a_url", # Will raise ValueError
+        "", # Will raise ValueError
+        None, # Will raise ValueError (handled by type hinting in real use, but good to test)
+    ]
+
+    for url in test_urls:
+        print(f"\nTesting URL: {url}")
+        try:
+            if url is None: # Simulate passing None which would be a TypeError if not caught by caller
+                # In real usage, type hints should prevent this, but for direct call test:
+                # FetcherFactory.get_fetcher(None) would fail earlier due to type check.
+                # Here we explicitly handle it for this test script's purpose.
+                print("Error: URL is None, cannot process.")
+                continue
+
+            fetcher_instance = FetcherFactory.get_fetcher(url)
+            print(f"  Fetcher: {type(fetcher_instance).__name__}")
+        except UnsupportedSourceError as e:
+            print(f"  Error: {e}")
+        except ValueError as e:
+            print(f"  Error: {e}")
+        except Exception as e:
+            print(f"  Unexpected Error: {e}")


### PR DESCRIPTION
Introduces a FetcherFactory to decouple the source fetcher from the core Orchestrator logic.

Key changes:
- Created `FetcherFactory` that selects the appropriate fetcher based on the story URL.
- `Orchestrator` now uses `FetcherFactory` instead of directly instantiating `RoyalRoadFetcher`.
- Added `UnsupportedSourceError` custom exception for unsupported URLs.
- Added unit tests for `FetcherFactory` to verify its logic.
- Updated relevant `__init__.py` files.

This change allows for easier addition of new webnovel sources in the future without modifying the Orchestrator's core code, adhering to the Open/Closed Principle.