### PR TITLE
Fix: Correct RoyalRoadFetcher instantiation error

### DIFF
--- a/webnovel_archiver/core/fetchers/exceptions.py
+++ b/webnovel_archiver/core/fetchers/exceptions.py
@@ -1,3 +1,7 @@
 class UnsupportedSourceError(Exception):
     """Custom exception for unsupported story sources."""
     pass
+
+class FetcherError(Exception):
+    """Base exception for fetcher-related errors."""
+    pass

--- a/webnovel_archiver/core/fetchers/royalroad_fetcher.py
+++ b/webnovel_archiver/core/fetchers/royalroad_fetcher.py
@@ -615,6 +615,22 @@ class RoyalRoadFetcher(BaseFetcher):
             logger.warning(f"Could not find the next chapter link on {chapter_page_url} after trying selectors: {', '.join(selectors_tried)}")
             return None
 
+    def get_source_specific_id(self, url: str) -> str:
+        """
+        Extracts the numerical fiction ID from a RoyalRoad URL.
+        Example: "https://www.royalroad.com/fiction/12345/some-story-title" -> "12345"
+        """
+        # Regex to match royalroad.com domain and extract fiction ID
+        match = re.search(r"royalroad.com/fiction/(\d+)", url)
+        if match:
+            return match.group(1)
+        else:
+            logger.warning(f"Could not extract fiction ID from RoyalRoad URL: {url}")
+            # Raise an error or return a specific value indicating failure,
+            # depending on how the caller (Orchestrator) should handle this.
+            # For now, let's raise ValueError as the Orchestrator might fall back.
+            raise ValueError(f"Could not parse RoyalRoad fiction ID from URL: {url}")
+
 if __name__ == '__main__':
     # Setup basic logging for the __main__ block
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
@@ -695,18 +711,3 @@ if __name__ == '__main__':
     #     logger.error(f"Failed to fetch live story '{story_url_live_test}': {e}")
     # except Exception as e:
     #     logger.error(f"An unexpected error occurred with live story '{story_url_live_test}': {e}")
-
-    def get_source_specific_id(self, url: str) -> str:
-        """
-        Extracts the numerical fiction ID from a RoyalRoad URL.
-        Example: "https://www.royalroad.com/fiction/12345/some-story-title" -> "12345"
-        """
-        match = re.search(r"/fiction/(\d+)", url)
-        if match:
-            return match.group(1)
-        else:
-            logger.warning(f"Could not extract fiction ID from RoyalRoad URL: {url}")
-            # Raise an error or return a specific value indicating failure,
-            # depending on how the caller (Orchestrator) should handle this.
-            # For now, let's raise ValueError as the Orchestrator might fall back.
-            raise ValueError(f"Could not parse RoyalRoad fiction ID from URL: {url}")

--- a/webnovel_archiver/tests/fetchers/test_royalroad_fetcher.py
+++ b/webnovel_archiver/tests/fetchers/test_royalroad_fetcher.py
@@ -1,0 +1,50 @@
+import pytest
+from webnovel_archiver.core.fetchers.royalroad_fetcher import RoyalRoadFetcher
+
+# Instantiate the fetcher once for all tests in this module
+fetcher = RoyalRoadFetcher()
+
+@pytest.mark.parametrize("url, expected_id", [
+    ("https://www.royalroad.com/fiction/12345/some-story-title", "12345"),
+    ("https://www.royalroad.com/fiction/12345", "12345"),
+    ("http://www.royalroad.com/fiction/67890/another-story", "67890"),
+    ("https://royalroad.com/fiction/54321/no-www", "54321"),
+    ("https://www.royalroad.com/fiction/1/short-id", "1"),
+    ("https://www.royalroad.com/fiction/111943/the-empress-of-nightmares-embraces-the-world-power", "111943"),
+])
+def test_get_source_specific_id_valid_urls(url, expected_id):
+    """Test that valid RoyalRoad URLs return the correct fiction ID."""
+    assert fetcher.get_source_specific_id(url) == expected_id
+
+@pytest.mark.parametrize("invalid_url", [
+    "https://www.royalroad.com/fictio/12345/some-story-title", # Misspelled 'fiction'
+    "https://www.royalroad.com/profile/12345", # Not a fiction URL
+    "https://www.another-site.com/fiction/12345", # Different domain
+    "https://www.royalroad.com/fiction//no-id", # No ID
+    "https://www.royalroad.com/fiction/abcde/letters-as-id", # Non-numeric ID
+    "http://royalroad.com/some/other/path",
+    "Just some random text",
+    "", # Empty string
+])
+def test_get_source_specific_id_invalid_urls(invalid_url):
+    """Test that invalid or non-matching URLs raise ValueError."""
+    with pytest.raises(ValueError):
+        fetcher.get_source_specific_id(invalid_url)
+
+def test_get_source_specific_id_url_with_query_params():
+    """Test URL with query parameters."""
+    url = "https://www.royalroad.com/fiction/77777/story-with-query?param=value&another=true"
+    expected_id = "77777"
+    assert fetcher.get_source_specific_id(url) == expected_id
+
+def test_get_source_specific_id_url_with_fragment():
+    """Test URL with a fragment."""
+    url = "https://www.royalroad.com/fiction/88888/story-with-fragment#section1"
+    expected_id = "88888"
+    assert fetcher.get_source_specific_id(url) == expected_id
+
+def test_get_source_specific_id_complex_url():
+    """Test a more complex URL combining features."""
+    url = "http://royalroad.com/fiction/99999/a-very-long-story-title-with-hyphens-and-numbers-123?utm_source=test&page=3#comments"
+    expected_id = "99999"
+    assert fetcher.get_source_specific_id(url) == expected_id


### PR DESCRIPTION
Moved get_source_specific_id into the RoyalRoadFetcher class definition to properly implement the abstract method from BaseFetcher.

Added unit tests for get_source_specific_id and adjusted its regex to be specific to royalroad.com URLs, ensuring correct ID parsing and error handling for invalid URLs.