### PR TITLE
Refactor: Decouple story ID from folder names

### DIFF
--- a/webnovel_archiver/core/fetchers/royalroad_fetcher.py
+++ b/webnovel_archiver/core/fetchers/royalroad_fetcher.py
@@ -626,21 +626,8 @@ class RoyalRoadFetcher(BaseFetcher):
             logger.warning(f"Could not find the next chapter link on {chapter_page_url} after trying selectors: {', '.join(selectors_tried)}")
             return None
 
-    def get_source_specific_id(self, url: str) -> str:
-        """
-        Extracts the numerical fiction ID from a RoyalRoad URL.
-        Example: "https://www.royalroad.com/fiction/12345/some-story-title" -> "12345"
-        """
-        # Regex to match royalroad.com domain and extract fiction ID
-        match = re.search(r"royalroad.com/fiction/(\d+)", url)
-        if match:
-            return match.group(1)
-        else:
-            logger.warning(f"Could not extract fiction ID from RoyalRoad URL: {url}")
-            # Raise an error or return a specific value indicating failure,
-            # depending on how the caller (Orchestrator) should handle this.
-            # For now, let's raise ValueError as the Orchestrator might fall back.
-            raise ValueError(f"Could not parse RoyalRoad fiction ID from URL: {url}")
+# The get_source_specific_id method defined earlier in the class (around line 98) is the correct one.
+# This duplicate definition below is removed.
 
 if __name__ == '__main__':
     # Setup basic logging for the __main__ block


### PR DESCRIPTION
- Ensured RoyalRoadFetcher generates a prefixed story ID (e.g., "royalroad-12345").
- Verified that MigrationManager correctly uses this permanent ID to build the master story index (index.json) from existing archives.
- Verified that PathManager and Orchestrator correctly use the permanent ID with the IndexManager to:
  - Create folders for new stories using a slug of the current title.
  - Rename story folders and update the index if a story's title changes, without duplicating archives.
- This change makes story identification robust against title updates and aligns with the planned decoupling strategy.